### PR TITLE
Add testnet deployment kit for Stagecoin and SentientCents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in your own values.
+# Never commit .env or private keys.
+
+# Testnet RPC URLs from a provider such as Alchemy, Infura, QuickNode, or Coinbase Developer Platform.
+SEPOLIA_RPC_URL=
+BASE_SEPOLIA_RPC_URL=
+
+# Private key for a testnet-only wallet. Do not use your main wallet.
+DEPLOYER_PRIVATE_KEY=
+
+# Optional explorer API keys for contract verification.
+ETHERSCAN_API_KEY=
+BASESCAN_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile contracts
+        run: npm run compile
+
+      - name: Test contracts
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build

--- a/docs/testnet-deployment.md
+++ b/docs/testnet-deployment.md
@@ -1,0 +1,95 @@
+# Testnet Deployment Guide
+
+This project deploys two ERC20-compatible contracts:
+
+- `Stagecoin` (`STAGE`) with a 5% transfer royalty
+- `SentientCents` (`SCENTS`) with 2 decimals and a 2.5% transfer royalty
+
+Deploy to testnet before any mainnet deployment.
+
+## 1. Install dependencies
+
+```bash
+npm install
+```
+
+## 2. Compile contracts
+
+```bash
+npm run compile
+```
+
+## 3. Run tests
+
+```bash
+npm test
+```
+
+Do not deploy until compile and tests pass.
+
+## 4. Create a testnet-only wallet
+
+Use a fresh wallet that does not hold mainnet assets. Export its private key only for local testnet deployment.
+
+Never commit `.env`.
+
+## 5. Configure environment
+
+Copy the sample environment file:
+
+```bash
+cp .env.example .env
+```
+
+Fill in:
+
+```bash
+SEPOLIA_RPC_URL=
+BASE_SEPOLIA_RPC_URL=
+DEPLOYER_PRIVATE_KEY=
+ETHERSCAN_API_KEY=
+BASESCAN_API_KEY=
+```
+
+Use either Sepolia or Base Sepolia first. Base Sepolia is usually a practical low-cost path for UI demos.
+
+## 6. Fund the deployer wallet
+
+Send a small amount of testnet ETH to the deployer wallet from a faucet for the network you plan to use.
+
+## 7. Deploy
+
+Sepolia:
+
+```bash
+npm run deploy:sepolia
+```
+
+Base Sepolia:
+
+```bash
+npm run deploy:base-sepolia
+```
+
+The script prints the deployed contract addresses and constructor arguments.
+
+## 8. Verify contracts
+
+After deployment, verify each contract with the printed constructor arguments.
+
+Example shape:
+
+```bash
+npm run verify:sepolia -- <CONTRACT_ADDRESS> "Stagecoin" "STAGE" <ADMIN_ADDRESS> <ROYALTY_ADDRESS> 500
+```
+
+```bash
+npm run verify:base-sepolia -- <CONTRACT_ADDRESS> "SentientCents" "SCENTS" <ADMIN_ADDRESS> <ROYALTY_ADDRESS> 250
+```
+
+## Safety notes
+
+- Testnet only until contracts have been reviewed.
+- Do not use your main wallet private key.
+- Do not promise legal copyright enforcement from token transfers alone.
+- Treat this as claim-staking and payment-routing infrastructure, not a complete legal rights system.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,8 @@
+require("dotenv").config();
 require("@nomicfoundation/hardhat-toolbox");
+
+const deployerKey = process.env.DEPLOYER_PRIVATE_KEY || "";
+const deployerAccounts = deployerKey ? [deployerKey] : [];
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
@@ -10,6 +14,33 @@ module.exports = {
         runs: 200
       }
     }
+  },
+  networks: {
+    sepolia: {
+      url: process.env.SEPOLIA_RPC_URL || "",
+      accounts: deployerAccounts
+    },
+    baseSepolia: {
+      url: process.env.BASE_SEPOLIA_RPC_URL || "",
+      accounts: deployerAccounts,
+      chainId: 84532
+    }
+  },
+  etherscan: {
+    apiKey: {
+      sepolia: process.env.ETHERSCAN_API_KEY || "",
+      baseSepolia: process.env.BASESCAN_API_KEY || ""
+    },
+    customChains: [
+      {
+        network: "baseSepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://api-sepolia.basescan.org/api",
+          browserURL: "https://sepolia.basescan.org"
+        }
+      }
+    ]
   },
   paths: {
     sources: "./contracts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "compile": "hardhat compile",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy:local": "hardhat run scripts/deploy.js --network localhost",
+    "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia",
+    "deploy:base-sepolia": "hardhat run scripts/deploy.js --network baseSepolia",
+    "verify:sepolia": "hardhat verify --network sepolia",
+    "verify:base-sepolia": "hardhat verify --network baseSepolia"
   },
   "keywords": [
     "blockchain",
@@ -23,6 +28,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.14",
     "chai": "^4.3.7",
+    "dotenv": "^16.4.5",
     "hardhat": "^2.12.0",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,41 @@
+const hre = require("hardhat");
+
+async function main() {
+  const [deployer] = await hre.ethers.getSigners();
+  const deployerAddress = await deployer.getAddress();
+
+  console.log("Deploying contracts with account:", deployerAddress);
+
+  const Stagecoin = await hre.ethers.getContractFactory("Stagecoin");
+  const stagecoin = await Stagecoin.deploy(
+    "Stagecoin",
+    "STAGE",
+    deployerAddress,
+    deployerAddress,
+    500
+  );
+  await stagecoin.deployed();
+
+  console.log("Stagecoin deployed to:", stagecoin.address);
+
+  const SentientCents = await hre.ethers.getContractFactory("SentientCents");
+  const sentientCents = await SentientCents.deploy(
+    "SentientCents",
+    "SCENTS",
+    deployerAddress,
+    deployerAddress,
+    250
+  );
+  await sentientCents.deployed();
+
+  console.log("SentientCents deployed to:", sentientCents.address);
+
+  console.log("\nVerification constructor args:");
+  console.log("Stagecoin:", ["Stagecoin", "STAGE", deployerAddress, deployerAddress, 500]);
+  console.log("SentientCents:", ["SentientCents", "SCENTS", deployerAddress, deployerAddress, 250]);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,7 +1,11 @@
 const hre = require("hardhat");
 
 async function main() {
-  const [deployer] = await hre.ethers.getSigners();
+  const signers = await hre.ethers.getSigners();
+  if (signers.length === 0) {
+    throw new Error("No deployer account found. Check your network configuration and private keys.");
+  }
+  const deployer = signers[0];
   const deployerAddress = await deployer.getAddress();
 
   console.log("Deploying contracts with account:", deployerAddress);

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -30,7 +30,7 @@ async function main() {
     deployerAddress,
     250
   );
-  await sentientCents.deployed();
+  await sentientCents.deployTransaction.wait(1);
 
   console.log("SentientCents deployed to:", sentientCents.address);
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -9,6 +9,8 @@ async function main() {
   const deployerAddress = await deployer.getAddress();
 
   console.log("Deploying contracts with account:", deployerAddress);
+  const balance = await deployer.getBalance();
+  console.log("Account balance:", hre.ethers.utils.formatEther(balance));
 
   const Stagecoin = await hre.ethers.getContractFactory("Stagecoin");
   const stagecoin = await Stagecoin.deploy(

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -18,7 +18,7 @@ async function main() {
     deployerAddress,
     500
   );
-  await stagecoin.deployed();
+  await stagecoin.deployTransaction.wait(1);
 
   console.log("Stagecoin deployed to:", stagecoin.address);
 


### PR DESCRIPTION
Adds a safe testnet deployment path for the Stagecoin and SentientCents contracts.

## What changed

- Adds deployment scripts for local, Sepolia, and Base Sepolia networks
- Adds dotenv support without committing secrets
- Adds Hardhat network configuration for Sepolia and Base Sepolia
- Adds `.env.example` with safe placeholders
- Adds `scripts/deploy.js` to deploy both contracts
- Adds `docs/testnet-deployment.md` with operator steps and safety notes
- Adds CI to compile contracts, run tests, and build the frontend

## Safety posture

This is testnet-first infrastructure. Do not deploy to mainnet from this branch. Use a fresh testnet-only wallet, verify compile/test/build first, and treat token royalties as payment-routing infrastructure rather than standalone legal enforcement.

## Commands

```bash
npm install
npm run compile
npm test
npm run build
npm run deploy:base-sepolia
```
